### PR TITLE
[decimal][xs]: changed decimal to number in datapackage.json

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -36,7 +36,7 @@
           },
           {
             "name": "height",
-            "type": "decimal",
+            "type": "number",
             "description": "External height of container in feet"
           },
           {


### PR DESCRIPTION
Changed type "decimal" to "number"  since spec does not support decimal type. 