### PR TITLE
Corrected height of 25GP

### DIFF
--- a/data/iso-container-codes.csv
+++ b/data/iso-container-codes.csv
@@ -87,7 +87,7 @@ B2G1,PASSIVE VENTS AT UPPER PART OF CARGO SPACE,24,8.5,22GP
 2225,Livestock Carrier,20,8.5,22GP
 22GP,Standard Dry,20,8.5,22GP
 2212,General Purpose (Hanging Garments),20,8.5,22GP
-25GP,High Cube,20,9.6,22GP
+25GP,High Cube,20,9.5,22GP
 22H0,Insulated (Conair),20,8.5,22HR
 22H1,Thermal Refrigerated/Heated,20,8.5,22HR
 22H2,Thermal Refrigerated/Heated,20,8.5,22HR


### PR DESCRIPTION
Height is 9'6" or 9.5ft in decimal. Must of been entered as 9.6 by accident.